### PR TITLE
feat: add contentlayer mdx posts and projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
 .env
+.contentlayer

--- a/content/blog/hello-world.mdx
+++ b/content/blog/hello-world.mdx
@@ -1,0 +1,22 @@
+---
+title: "Hello World"
+summary: "Introductory post"
+date: "2024-01-01"
+tags: ["intro", "hello"]
+cover: "/images/hello.jpg"
+---
+
+Welcome to my blog.
+
+<Callout>This is a callout.</Callout>
+
+```
+console.log('Hello, world!');
+```
+
+| Feature | Description |
+|---------|-------------|
+| MDX     | Markdown + JSX |
+| Contentlayer | Content management |
+
+<ImageCaption src="/images/hello.jpg" alt="Hello" caption="Sample image" />

--- a/content/projects/sample-project.mdx
+++ b/content/projects/sample-project.mdx
@@ -1,0 +1,17 @@
+---
+title: "Sample Project"
+timeline: "2023"
+role: "Developer"
+stack: ["Next.js", "TypeScript"]
+outcomes: ["Improved performance", "Better UX"]
+links:
+  - label: "GitHub"
+    url: "https://github.com/"
+tags: ["web", "nextjs"]
+---
+
+This is a sample project case study.
+
+<Callout type="info">Key achievements highlighted here.</Callout>
+
+<ImageCaption src="/images/project.jpg" alt="Project" caption="Project overview" />

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,0 +1,61 @@
+import { defineDocumentType, defineNestedType, makeSource } from 'contentlayer/source-files';
+import remarkGfm from 'remark-gfm';
+import readingTime from 'reading-time';
+
+const Link = defineNestedType(() => ({
+  name: 'Link',
+  fields: {
+    label: { type: 'string', required: true },
+    url: { type: 'string', required: true },
+  },
+}));
+
+export const Post = defineDocumentType(() => ({
+  name: 'Post',
+  filePathPattern: 'blog/*.mdx',
+  contentType: 'mdx',
+  fields: {
+    title: { type: 'string', required: true },
+    summary: { type: 'string', required: true },
+    date: { type: 'date', required: true },
+    tags: { type: 'list', of: { type: 'string' }, required: true },
+    cover: { type: 'string', required: true },
+  },
+  computedFields: {
+    slug: {
+      type: 'string',
+      resolve: (doc) => doc._raw.sourceFileName.replace(/\.mdx$/, ''),
+    },
+    readingTime: {
+      type: 'string',
+      resolve: (doc) => readingTime(doc.body.raw).text,
+    },
+  },
+}));
+
+export const Project = defineDocumentType(() => ({
+  name: 'Project',
+  filePathPattern: 'projects/*.mdx',
+  contentType: 'mdx',
+  fields: {
+    title: { type: 'string', required: true },
+    timeline: { type: 'string', required: true },
+    role: { type: 'string', required: true },
+    stack: { type: 'list', of: { type: 'string' }, required: true },
+    outcomes: { type: 'list', of: { type: 'string' }, required: true },
+    links: { type: 'list', of: Link, required: true },
+    tags: { type: 'list', of: { type: 'string' }, required: true },
+  },
+  computedFields: {
+    slug: {
+      type: 'string',
+      resolve: (doc) => doc._raw.sourceFileName.replace(/\.mdx$/, ''),
+    },
+  },
+}));
+
+export default makeSource({
+  contentDirPath: 'content',
+  documentTypes: [Post, Project],
+  mdx: { remarkPlugins: [remarkGfm] },
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
+import { withContentlayer } from "next-contentlayer";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
 };
 
-export default nextConfig;
+export default withContentlayer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "autoprefixer": "10.4.14",
     "postcss": "8.4.27",
     "eslint": "8.50.0",
-    "eslint-config-next": "14.1.0"
+    "eslint-config-next": "14.1.0",
+    "contentlayer": "^0.3.4",
+    "next-contentlayer": "^0.3.4",
+    "reading-time": "^1.5.0",
+    "remark-gfm": "^3.0.1"
   }
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { allPosts } from "contentlayer/generated";
+import { MDXComponents } from "@/components/mdx-components";
+import { useMDXComponent } from "next-contentlayer/hooks";
+
+export async function generateStaticParams() {
+  return allPosts.map((post) => ({ slug: post.slug }));
+}
+
+export default function BlogPostPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const post = allPosts.find((p) => p.slug === params.slug);
+  if (!post) notFound();
+  const MDXContent = useMDXComponent(post.body.code);
+  return (
+    <article className="prose dark:prose-invert">
+      <h1>{post.title}</h1>
+      <MDXContent components={MDXComponents} />
+    </article>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,26 @@
+import Link from "next/link";
+import { allPosts } from "contentlayer/generated";
+
 export default function BlogPage() {
+  const posts = allPosts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
   return (
     <section>
       <h1 className="text-3xl font-bold">Blog</h1>
-      <p className="mt-4">Posts will be available soon.</p>
+      <ul className="mt-4 space-y-4">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link
+              href={`/blog/${post.slug}`}
+              className="text-xl font-semibold"
+            >
+              {post.title}
+            </Link>
+            <p className="text-sm text-gray-600">{post.summary}</p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { allProjects } from "contentlayer/generated";
+import { MDXComponents } from "@/components/mdx-components";
+import { useMDXComponent } from "next-contentlayer/hooks";
+
+export async function generateStaticParams() {
+  return allProjects.map((p) => ({ slug: p.slug }));
+}
+
+export default function ProjectPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const project = allProjects.find((p) => p.slug === params.slug);
+  if (!project) notFound();
+  const MDXContent = useMDXComponent(project.body.code);
+  return (
+    <article className="prose dark:prose-invert">
+      <h1>{project.title}</h1>
+      <MDXContent components={MDXComponents} />
+    </article>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,23 @@
+import Link from "next/link";
+import { allProjects } from "contentlayer/generated";
+
 export default function ProjectsPage() {
   return (
     <section>
       <h1 className="text-3xl font-bold">Projects</h1>
-      <p className="mt-4">A list of my work will appear here.</p>
+      <ul className="mt-4 space-y-4">
+        {allProjects.map((project) => (
+          <li key={project.slug}>
+            <Link
+              href={`/projects/${project.slug}`}
+              className="text-xl font-semibold"
+            >
+              {project.title}
+            </Link>
+            <p className="text-sm text-gray-600">{project.timeline}</p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -1,0 +1,69 @@
+import Image from "next/image";
+import { ReactNode } from "react";
+
+export function Callout({
+  children,
+  type = "info",
+}: {
+  children: ReactNode;
+  type?: "info" | "warn";
+}) {
+  const colors: Record<string, string> = {
+    info: "border-blue-500 bg-blue-50",
+    warn: "border-yellow-500 bg-yellow-50",
+  };
+  return (
+    <div className={`my-4 border-l-4 p-4 ${colors[type]}`}>{children}</div>
+  );
+}
+
+export function CodeBlock(
+  props: React.HTMLAttributes<HTMLPreElement>
+): JSX.Element {
+  return (
+    <pre
+      {...props}
+      className="overflow-x-auto rounded bg-gray-800 p-4 text-sm text-gray-100"
+    />
+  );
+}
+
+export function Table({ children }: { children: ReactNode }) {
+  return (
+    <div className="my-4 overflow-x-auto">
+      <table className="w-full border-collapse">{children}</table>
+    </div>
+  );
+}
+
+export function ImageCaption({
+  src,
+  alt,
+  caption,
+}: {
+  src: string;
+  alt: string;
+  caption: string;
+}) {
+  return (
+    <figure className="my-4">
+      <Image
+        src={src}
+        alt={alt}
+        width={800}
+        height={450}
+        className="rounded"
+      />
+      <figcaption className="mt-2 text-center text-sm text-gray-500">
+        {caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+export const MDXComponents = {
+  Callout,
+  pre: CodeBlock,
+  table: Table,
+  ImageCaption,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "contentlayer/generated",
     "**/*.ts",
     "**/*.tsx",
     "**/*.js",


### PR DESCRIPTION
## Summary
- configure Contentlayer with blog and project document types
- add MDX components for callouts, code, tables, and captions
- generate blog and project pages from MDX content

## Testing
- `npx contentlayer build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/contentlayer)*
- `npm run lint` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689af5ad48b48322b95c175d9641f5fd