### PR TITLE
Implement blog pagination, tags, and feed routes

### DIFF
--- a/content/blog/hello-world.mdx
+++ b/content/blog/hello-world.mdx
@@ -8,6 +8,8 @@ cover: "/images/hello.jpg"
 
 Welcome to my blog.
 
+## Features
+
 <Callout>This is a callout.</Callout>
 
 ```

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -2,6 +2,14 @@ import { defineDocumentType, defineNestedType, makeSource } from 'contentlayer/s
 import remarkGfm from 'remark-gfm';
 import readingTime from 'reading-time';
 
+function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
 const Link = defineNestedType(() => ({
   name: 'Link',
   fields: {
@@ -29,6 +37,17 @@ export const Post = defineDocumentType(() => ({
     readingTime: {
       type: 'string',
       resolve: (doc) => readingTime(doc.body.raw).text,
+    },
+    toc: {
+      type: 'json',
+      resolve: (doc) => {
+        const headingLines = doc.body.raw.match(/^#{1,3}[^#].*/gm) ?? [];
+        return headingLines.map((line) => {
+          const level = line.startsWith('###') ? 3 : line.startsWith('##') ? 2 : 1;
+          const title = line.replace(/^#{1,3}\s*/, '').trim();
+          return { level, title, slug: slugify(title) };
+        });
+      },
     },
   },
 }));

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
 import { MDXComponents } from "@/components/mdx-components";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -18,6 +19,34 @@ export default function BlogPostPage({
   return (
     <article className="prose dark:prose-invert">
       <h1>{post.title}</h1>
+      <p className="text-sm text-gray-500">
+        {new Date(post.date).toDateString()} · {post.readingTime}
+      </p>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {post.tags.map((tag) => (
+          <Link
+            key={tag}
+            href={`/blog/tag/${tag}`}
+            className="text-xs text-blue-600 hover:underline"
+          >
+            #{tag}
+          </Link>
+        ))}
+      </div>
+      {post.toc.length > 0 && (
+        <nav className="mb-8 border-l pl-4">
+          <h2 className="text-lg font-semibold">Table of Contents</h2>
+          <ul className="mt-2 space-y-1 text-sm">
+            {post.toc.map((item) => (
+              <li key={item.slug} style={{ marginLeft: (item.level - 1) * 16 }}>
+                <a href={`#${item.slug}`} className="hover:underline">
+                  {item.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
       <MDXContent components={MDXComponents} />
     </article>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,15 +1,27 @@
 import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
 
-export default function BlogPage() {
+const POSTS_PER_PAGE = 5;
+
+export default function BlogPage({
+  searchParams,
+}: {
+  searchParams: { page?: string };
+}) {
+  const page = parseInt(searchParams.page ?? "1", 10);
   const posts = allPosts.sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
+  const paginated = posts.slice(
+    (page - 1) * POSTS_PER_PAGE,
+    page * POSTS_PER_PAGE
   );
   return (
     <section>
       <h1 className="text-3xl font-bold">Blog</h1>
       <ul className="mt-4 space-y-4">
-        {posts.map((post) => (
+        {paginated.map((post) => (
           <li key={post.slug}>
             <Link
               href={`/blog/${post.slug}`}
@@ -18,9 +30,33 @@ export default function BlogPage() {
               {post.title}
             </Link>
             <p className="text-sm text-gray-600">{post.summary}</p>
+            <p className="text-xs text-gray-500">
+              {new Date(post.date).toDateString()} · {post.readingTime}
+            </p>
+            <div className="mt-1 flex flex-wrap gap-2">
+              {post.tags.map((tag) => (
+                <Link
+                  key={tag}
+                  href={`/blog/tag/${tag}`}
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  #{tag}
+                </Link>
+              ))}
+            </div>
           </li>
         ))}
       </ul>
+      <div className="mt-8 flex justify-between">
+        {page > 1 ? (
+          <Link href={`/blog?page=${page - 1}`}>Previous</Link>
+        ) : (
+          <span />
+        )}
+        {page < totalPages && (
+          <Link href={`/blog?page=${page + 1}`}>Next</Link>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { allPosts } from "contentlayer/generated";
+
+export async function generateStaticParams() {
+  const tags = Array.from(new Set(allPosts.flatMap((post) => post.tags)));
+  return tags.map((tag) => ({ tag }));
+}
+
+export default function TagPage({
+  params,
+}: {
+  params: { tag: string };
+}) {
+  const posts = allPosts
+    .filter((p) => p.tags.includes(params.tag))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return (
+    <section>
+      <h1 className="text-3xl font-bold">Tag: {params.tag}</h1>
+      <ul className="mt-4 space-y-4">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link
+              href={`/blog/${post.slug}`}
+              className="text-xl font-semibold"
+            >
+              {post.title}
+            </Link>
+            <p className="text-sm text-gray-600">{post.summary}</p>
+            <p className="text-xs text-gray-500">
+              {new Date(post.date).toDateString()} · {post.readingTime}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,17 @@
+import { allPosts } from "contentlayer/generated";
+
+export async function GET() {
+  const siteUrl = "https://example.com";
+  const posts = allPosts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+  const items = posts
+    .map(
+      (post) => `\n    <item>\n      <title>${post.title}</title>\n      <link>${siteUrl}/blog/${post.slug}</link>\n      <guid>${siteUrl}/blog/${post.slug}</guid>\n      <pubDate>${new Date(post.date).toUTCString()}</pubDate>\n      <description>${post.summary}</description>\n    </item>`
+    )
+    .join("");
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>Ratan Portfolio Blog</title>\n    <link>${siteUrl}/blog</link>\n    <description>Blog posts</description>${items}\n  </channel>\n</rss>`;
+  return new Response(xml, {
+    headers: { "Content-Type": "application/rss+xml" },
+  });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from "next";
+import { allPosts } from "contentlayer/generated";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteUrl = "https://example.com";
+  const posts = allPosts.map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: post.date,
+  }));
+  return [
+    { url: siteUrl, lastModified: new Date() },
+    { url: `${siteUrl}/about`, lastModified: new Date() },
+    { url: `${siteUrl}/contact`, lastModified: new Date() },
+    { url: `${siteUrl}/projects`, lastModified: new Date() },
+    { url: `${siteUrl}/blog`, lastModified: new Date() },
+    ...posts,
+  ];
+}

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { ReactNode } from "react";
+import { cn, slugify } from "@/lib/utils";
 
 export function Callout({
   children,
@@ -23,9 +24,19 @@ export function CodeBlock(
   return (
     <pre
       {...props}
-      className="overflow-x-auto rounded bg-gray-800 p-4 text-sm text-gray-100"
+      className={cn("overflow-x-auto rounded p-4", props.className)}
     />
   );
+}
+
+function createHeading(
+  Tag: keyof JSX.IntrinsicElements
+): ({ children }: { children: ReactNode }) => JSX.Element {
+  return ({ children }) => {
+    const id = slugify(String(children));
+    const Component = Tag as any;
+    return <Component id={id}>{children}</Component>;
+  };
 }
 
 export function Table({ children }: { children: ReactNode }) {
@@ -66,4 +77,7 @@ export const MDXComponents = {
   pre: CodeBlock,
   table: Table,
   ImageCaption,
+  h1: createHeading("h1"),
+  h2: createHeading("h2"),
+  h3: createHeading("h3"),
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,11 @@
 export function cn(...classes: (string | null | undefined | boolean)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-");
+}


### PR DESCRIPTION
## Summary
- add slug utility and computed TOC field
- paginate blog index with reading time and tags
- render post TOC and tag pages
- expose RSS feed and sitemap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/reading-time)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afc32a9648322ace31c0f7aa4c31c