### PR TITLE
Add hero and content sections to homepage

### DIFF
--- a/public/linkedin.svg
+++ b/public/linkedin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#0A66C2"/>
+  <text x="6" y="17" font-size="12" font-family="Arial, sans-serif" font-weight="bold" fill="white">in</text>
+</svg>

--- a/public/shl-medical.svg
+++ b/public/shl-medical.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="white"/>
+  <text x="10" y="28" font-size="28" font-family="Arial, sans-serif" font-weight="bold" fill="#0055A5">SHL</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,86 @@
+import Link from "next/link";
+import Image from "next/image";
+import { allPosts, allProjects } from "contentlayer/generated";
+
 export default function HomePage() {
+  const posts = allPosts
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 3);
+  const projects = allProjects;
   return (
-    <section>
-      <h1 className="text-3xl font-bold">Welcome to my portfolio</h1>
-      <p className="mt-4">This is the home page.</p>
-    </section>
+    <div className="space-y-16">
+      <section className="py-20 text-center">
+        <h1 className="text-4xl font-bold">Ratan Lal Bunkar</h1>
+        <p className="mt-2 text-xl text-muted-foreground">Full Stack Developer</p>
+        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+          I craft responsive web applications and share insights on modern
+          development.
+        </p>
+        <div className="mt-6 flex justify-center gap-4">
+          <Link
+            href="/projects"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            View Projects
+          </Link>
+          <Link
+            href="/blog"
+            className="inline-flex items-center justify-center rounded-md border border-input px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+          >
+            Read Blog
+          </Link>
+        </div>
+        <div className="mt-8 flex justify-center gap-6">
+          <a
+            href="https://www.shl-medical.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Image src="/shl-medical.svg" alt="SHL Medical" width={120} height={40} />
+          </a>
+          <a
+            href="https://linkedin.com/in/ratanlalbunkar/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Image src="/linkedin.svg" alt="LinkedIn" width={24} height={24} />
+          </a>
+        </div>
+      </section>
+      <section>
+        <h2 className="mb-4 text-2xl font-bold">Featured Projects</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <Link
+              key={project.slug}
+              href={`/projects/${project.slug}`}
+              className="block rounded-lg border p-4 hover:shadow"
+            >
+              <h3 className="text-lg font-semibold">{project.title}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {project.timeline}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h2 className="mb-4 text-2xl font-bold">Latest Blog Posts</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          {posts.map((post) => (
+            <Link
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="block rounded-lg border p-4 hover:shadow"
+            >
+              <h3 className="text-lg font-semibold">{post.title}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {post.summary}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- design hero section with name, role, short pitch, and CTAs for projects and blog
- show grid of featured projects and latest blog posts
- include logos linking to SHL Medical and LinkedIn

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found, dependencies not installed)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_689bf4fa203883229172598642e4ea3a