### PR TITLE
feat: add SEO metadata and dynamic OG images

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "About",
+  alternates: { canonical: absoluteUrl("/about") },
+};
+
 export default function AboutPage() {
   return (
     <section>

--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+import { allPosts } from "contentlayer/generated";
+
+export const runtime = "edge";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image({ params }: { params: { slug: string } }) {
+  const post = allPosts.find((p) => p.slug === params.slug);
+  if (!post) {
+    return new ImageResponse(
+      <div style={{ fontSize: 64, padding: 128 }}>Not found</div>,
+      { ...size }
+    );
+  }
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#fff",
+          color: "#000",
+        }}
+      >
+        <div style={{ fontSize: 64, fontWeight: 700 }}>{post.title}</div>
+        <div style={{ marginTop: 40, fontSize: 32 }}>
+          {post.tags.map((t) => `#${t}`).join(" ")}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,9 +3,42 @@ import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
 import { MDXComponents } from "@/components/mdx-components";
 import { useMDXComponent } from "next-contentlayer/hooks";
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 export async function generateStaticParams() {
   return allPosts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const post = allPosts.find((p) => p.slug === params.slug);
+  if (!post) return {};
+  const url = absoluteUrl(`/blog/${post.slug}`);
+  const ogImage = absoluteUrl(`/blog/${post.slug}/opengraph-image`);
+  return {
+    title: post.title,
+    description: post.summary,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title: post.title,
+      description: post.summary,
+      publishedTime: post.date,
+      tags: post.tags,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.summary,
+      images: [ogImage],
+    },
+  };
 }
 
 export default function BlogPostPage({

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 const POSTS_PER_PAGE = 5;
 
@@ -60,3 +62,8 @@ export default function BlogPage({
     </section>
   );
 }
+
+export const metadata: Metadata = {
+  title: "Blog",
+  alternates: { canonical: absoluteUrl("/blog") },
+};

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,9 +1,22 @@
 import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 export async function generateStaticParams() {
   const tags = Array.from(new Set(allPosts.flatMap((post) => post.tags)));
   return tags.map((tag) => ({ tag }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { tag: string };
+}): Promise<Metadata> {
+  return {
+    title: `Tag: ${params.tag}`,
+    alternates: { canonical: absoluteUrl(`/blog/tag/${params.tag}`) },
+  };
 }
 
 export default function TagPage({

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  alternates: { canonical: absoluteUrl("/contact") },
+};
+
 export default function ContactPage() {
   return (
     <section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,31 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { siteConfig } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Ratan Portfolio',
-  description: 'Portfolio site built with Next.js',
+  metadataBase: new URL(siteConfig.url),
+  title: {
+    default: siteConfig.name,
+    template: `%s | ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+  alternates: {
+    canonical: siteConfig.url,
+  },
+  openGraph: {
+    title: siteConfig.name,
+    description: siteConfig.description,
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteConfig.name,
+    description: siteConfig.description,
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+import { allProjects } from "contentlayer/generated";
+
+export const runtime = "edge";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image({ params }: { params: { slug: string } }) {
+  const project = allProjects.find((p) => p.slug === params.slug);
+  if (!project) {
+    return new ImageResponse(
+      <div style={{ fontSize: 64, padding: 128 }}>Not found</div>,
+      { ...size }
+    );
+  }
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#fff",
+          color: "#000",
+        }}
+      >
+        <div style={{ fontSize: 64, fontWeight: 700 }}>{project.title}</div>
+        <div style={{ marginTop: 40, fontSize: 32 }}>
+          {project.tags.map((t) => `#${t}`).join(" ")}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,9 +2,37 @@ import { notFound } from "next/navigation";
 import { allProjects } from "contentlayer/generated";
 import { MDXComponents } from "@/components/mdx-components";
 import { useMDXComponent } from "next-contentlayer/hooks";
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 export async function generateStaticParams() {
   return allProjects.map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const project = allProjects.find((p) => p.slug === params.slug);
+  if (!project) return {};
+  const url = absoluteUrl(`/projects/${project.slug}`);
+  const ogImage = absoluteUrl(`/projects/${project.slug}/opengraph-image`);
+  return {
+    title: project.title,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title: project.title,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: project.title,
+      images: [ogImage],
+    },
+  };
 }
 
 export default function ProjectPage({

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { allProjects } from "contentlayer/generated";
+import type { Metadata } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 export default function ProjectsPage() {
   return (
@@ -21,3 +23,8 @@ export default function ProjectsPage() {
     </section>
   );
 }
+
+export const metadata: Metadata = {
+  title: "Projects",
+  alternates: { canonical: absoluteUrl("/projects") },
+};

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+import { siteConfig, absoluteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: absoluteUrl("/sitemap.xml"),
+    host: siteConfig.url,
+  };
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,7 +1,8 @@
 import { allPosts } from "contentlayer/generated";
+import { siteConfig } from "@/lib/site";
 
 export async function GET() {
-  const siteUrl = "https://example.com";
+  const siteUrl = siteConfig.url;
   const posts = allPosts.sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,18 +1,18 @@
 import { MetadataRoute } from "next";
 import { allPosts } from "contentlayer/generated";
+import { absoluteUrl, siteConfig } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const siteUrl = "https://example.com";
   const posts = allPosts.map((post) => ({
-    url: `${siteUrl}/blog/${post.slug}`,
+    url: absoluteUrl(`/blog/${post.slug}`),
     lastModified: post.date,
   }));
   return [
-    { url: siteUrl, lastModified: new Date() },
-    { url: `${siteUrl}/about`, lastModified: new Date() },
-    { url: `${siteUrl}/contact`, lastModified: new Date() },
-    { url: `${siteUrl}/projects`, lastModified: new Date() },
-    { url: `${siteUrl}/blog`, lastModified: new Date() },
+    { url: siteConfig.url, lastModified: new Date() },
+    { url: absoluteUrl("/about"), lastModified: new Date() },
+    { url: absoluteUrl("/contact"), lastModified: new Date() },
+    { url: absoluteUrl("/projects"), lastModified: new Date() },
+    { url: absoluteUrl("/blog"), lastModified: new Date() },
     ...posts,
   ];
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,9 @@
+export const siteConfig = {
+  name: "Ratan Portfolio",
+  description: "Portfolio site built with Next.js",
+  url: process.env.NEXT_PUBLIC_SITE_URL || "https://example.com",
+};
+
+export function absoluteUrl(path: string) {
+  return `${siteConfig.url}${path}`;
+}


### PR DESCRIPTION
## Summary
- centralize site configuration for canonical URLs and metadata
- add robots.txt and sitemap routes
- generate metadata and dynamic OpenGraph images for posts and projects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_689bfa5bd78c83229d1f963cb65444e4