### PR TITLE
feat: add pagefind search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .next
 .env
 .contentlayer
+out

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import { withContentlayer } from "next-contentlayer";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default withContentlayer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && npx pagefind --site out",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -38,6 +38,9 @@ export async function generateMetadata({
       description: post.summary,
       images: [ogImage],
     },
+    other: {
+      "pagefind:meta:tags": post.tags.join(","),
+    },
   };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import Search from '@/components/Search';
 import { siteConfig } from '@/lib/site';
 
 export const metadata: Metadata = {
@@ -33,6 +34,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
+        <Search />
         <Header />
         <main className="max-w-5xl mx-auto p-4">
           {children}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -32,6 +32,9 @@ export async function generateMetadata({
       title: project.title,
       images: [ogImage],
     },
+    other: {
+      "pagefind:meta:tags": project.tags.join(","),
+    },
   };
 }
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,108 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function Search() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [pagefind, setPagefind] = useState<any>(null)
+  const [results, setResults] = useState<any[]>([])
+
+  useEffect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen(true)
+      }
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    window.addEventListener('keydown', onKeydown)
+    return () => window.removeEventListener('keydown', onKeydown)
+  }, [])
+
+  useEffect(() => {
+    if (!open || pagefind) return
+    const script = document.createElement('script')
+    script.src = '/pagefind/pagefind.js'
+    script.type = 'text/javascript'
+    script.onload = async () => {
+      const pf = (window as any).pagefind
+      if (pf) {
+        await pf.init()
+        setPagefind(pf)
+      }
+    }
+    document.body.appendChild(script)
+    return () => {
+      document.body.removeChild(script)
+    }
+  }, [open, pagefind])
+
+  async function handleSearch(term: string) {
+    setQuery(term)
+    if (!pagefind || !term) {
+      setResults([])
+      return
+    }
+    const search = await pagefind.search(term)
+    const res = await Promise.all(search.results.map((r: any) => r.data()))
+    setResults(res)
+  }
+
+  return (
+    <div>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white dark:bg-gray-900 w-full max-w-xl rounded p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              autoFocus
+              type="text"
+              value={query}
+              onChange={(e) => handleSearch(e.target.value)}
+              placeholder="Search..."
+              className="w-full mb-4 border p-2 rounded bg-gray-50 dark:bg-gray-800"
+            />
+            <ul className="space-y-4 max-h-96 overflow-y-auto">
+              {results.map((r) => (
+                <li key={r.url}>
+                  <a href={r.url} className="block" onClick={() => setOpen(false)}>
+                    <h3 className="font-semibold" dangerouslySetInnerHTML={{ __html: r.meta?.title || r.url }} />
+                    {r.excerpt && (
+                      <p
+                        className="text-sm text-gray-600 dark:text-gray-400"
+                        dangerouslySetInnerHTML={{ __html: r.excerpt }}
+                      />
+                    )}
+                    {r.meta?.tags && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {String(r.meta.tags)
+                          .split(',')
+                          .map((tag: string) => (
+                            <span
+                              key={tag}
+                              className="text-xs bg-gray-200 dark:bg-gray-700 px-1 rounded"
+                            >
+                              {tag.trim()}
+                            </span>
+                          ))}
+                      </div>
+                    )}
+                  </a>
+                </li>
+              ))}
+              {query && results.length === 0 && <li>No results found.</li>}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- enable static export and Pagefind indexing during build
- expose page tags for Pagefind and wire up search dialog triggered by Cmd/Ctrl+K

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bff99d6688322b326b046859e7a0c