### PR TITLE
feat: add giscus comments

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { MDXComponents } from "@/components/mdx-components";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import type { Metadata } from "next";
 import { absoluteUrl } from "@/lib/site";
+import Comments from "@/components/Comments";
 
 export async function generateStaticParams() {
   return allPosts.map((post) => ({ slug: post.slug }));
@@ -84,6 +85,9 @@ export default function BlogPostPage({
         </nav>
       )}
       <MDXContent components={MDXComponents} />
+      <div className="mt-8">
+        <Comments slug={post.slug} />
+      </div>
     </article>
   );
 }

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from "react";
+
+export default function Comments({ slug }: { slug: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!loaded || !ref.current) return;
+    const script = document.createElement("script");
+    script.src = "https://giscus.app/client.js";
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    script.setAttribute("data-repo", process.env.NEXT_PUBLIC_GISCUS_REPO!);
+    script.setAttribute(
+      "data-repo-id",
+      process.env.NEXT_PUBLIC_GISCUS_REPOSITORY_ID!
+    );
+    script.setAttribute("data-category", process.env.NEXT_PUBLIC_GISCUS_CATEGORY!);
+    script.setAttribute(
+      "data-category-id",
+      process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID!
+    );
+    script.setAttribute("data-mapping", "specific");
+    script.setAttribute("data-term", slug);
+    script.setAttribute("data-strict", "0");
+    script.setAttribute("data-reactions-enabled", "1");
+    script.setAttribute("data-emit-metadata", "0");
+    script.setAttribute("data-input-position", "bottom");
+    script.setAttribute("data-lang", "en");
+    script.setAttribute(
+      "data-theme",
+      document.documentElement.classList.contains("dark") ? "dark" : "light"
+    );
+    script.setAttribute("data-loading", "lazy");
+    ref.current.appendChild(script);
+  }, [loaded, slug]);
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const theme = document.documentElement.classList.contains("dark")
+        ? "dark"
+        : "light";
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        "iframe.giscus-frame"
+      );
+      iframe?.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme } } },
+        "https://giscus.app"
+      );
+    };
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setLoaded(true);
+        observer.disconnect();
+      }
+    });
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return <div ref={ref} />;
+}
+


### PR DESCRIPTION
## Summary
- integrate Giscus comments under blog posts with slug-based discussion mapping
- sync comment theme with site light/dark mode
- load comments lazily when the section enters the viewport

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b21f5a483229de54bea72153cb5