### PR TITLE
Add Plausible analytics and event tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
@@ -33,6 +34,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <Script
+          src="https://plausible.io/js/script.js"
+          data-domain={new URL(siteConfig.url).hostname}
+          data-auto-track-outbound-links="true"
+        />
+      </head>
       <body>
         <Search />
         <Header />

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -48,6 +48,7 @@ export default function Search() {
     const search = await pagefind.search(term)
     const res = await Promise.all(search.results.map((r: any) => r.data()))
     setResults(res)
+    ;(window as any).plausible?.('search', { props: { query: term } })
   }
 
   return (


### PR DESCRIPTION
## Summary
- integrate Plausible analytics via Next.js Script component
- track search queries as custom events

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c1e2f79948322860f1c3afd20d944