### PR TITLE
feat: improve core web vitals and accessibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,4 +73,13 @@
   body {
     @apply bg-background text-foreground;
   }
+  :focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2;
+  }
+}
+
+@layer utilities {
+  .skip-to-content {
+    @apply sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
+import { Inter } from 'next/font/google';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Search from '@/components/Search';
 import { siteConfig } from '@/lib/site';
+
+const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.url),
@@ -35,16 +38,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <link rel="prefetch" href="/projects" />
+        <link rel="prefetch" href="/blog" />
         <Script
           src="https://plausible.io/js/script.js"
           data-domain={new URL(siteConfig.url).hostname}
           data-auto-track-outbound-links="true"
         />
       </head>
-      <body>
+      <body className={inter.className}>
+        <a href="#main-content" className="skip-to-content">Skip to content</a>
         <Search />
         <Header />
-        <main className="max-w-5xl mx-auto p-4">
+        <main id="main-content" className="max-w-5xl mx-auto p-4">
           {children}
         </main>
         <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,12 +19,14 @@ export default function HomePage() {
         <div className="mt-6 flex justify-center gap-4">
           <Link
             href="/projects"
+            prefetch
             className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             View Projects
           </Link>
           <Link
             href="/blog"
+            prefetch
             className="inline-flex items-center justify-center rounded-md border border-input px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
           >
             Read Blog
@@ -54,6 +56,7 @@ export default function HomePage() {
             <Link
               key={project.slug}
               href={`/projects/${project.slug}`}
+              prefetch
               className="block rounded-lg border p-4 hover:shadow"
             >
               <h3 className="text-lg font-semibold">{project.title}</h3>
@@ -71,6 +74,7 @@ export default function HomePage() {
             <Link
               key={post.slug}
               href={`/blog/${post.slug}`}
+              prefetch
               className="block rounded-lg border p-4 hover:shadow"
             >
               <h3 className="text-lg font-semibold">{post.title}</h3>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,19 +14,31 @@ const links = [
 export default function Header() {
   const [open, setOpen] = useState(false);
   return (
-    <header className="bg-gray-100 dark:bg-gray-800">
+    <header className="bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100">
       <div className="max-w-5xl mx-auto p-4 flex flex-wrap items-center justify-between">
-        <Link href="/" className="text-xl font-bold">Ratan</Link>
+        <Link href="/" prefetch className="text-xl font-bold">
+          Ratan
+        </Link>
         <button
           className="md:hidden p-2 ml-auto"
           onClick={() => setOpen(!open)}
           aria-label="Toggle navigation"
+          aria-expanded={open}
+          aria-controls="primary-navigation"
         >
           ☰
         </button>
-        <nav className={`${open ? 'block' : 'hidden'} w-full md:w-auto md:flex gap-4 items-center mt-4 md:mt-0`}>
+        <nav
+          id="primary-navigation"
+          className={`${open ? 'block' : 'hidden'} w-full md:w-auto md:flex gap-4 items-center mt-4 md:mt-0`}
+        >
           {links.map((link) => (
-            <Link key={link.href} href={link.href} className="block">
+            <Link
+              key={link.href}
+              href={link.href}
+              prefetch
+              className="block px-2 py-1"
+            >
               {link.label}
             </Link>
           ))}

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -78,6 +78,14 @@ export const MDXComponents = {
   pre: CodeBlock,
   table: Table,
   ImageCaption,
+  img: (props: any) => (
+    <Image
+      {...props}
+      alt={props.alt || ""}
+      width={props.width || 800}
+      height={props.height || 600}
+    />
+  ),
   CaseStudy,
   h1: createHeading("h1"),
   h2: createHeading("h2"),


### PR DESCRIPTION
## Summary
- add skip link, focus ring, and explicit prefetch for primary pages
- integrate Inter font to minimize layout shift and improve color contrast in header
- ensure MDX images use `next/image`

## Testing
- `npm install --no-audit --no-fund --legacy-peer-deps` *(fails: 403 Forbidden for reading-time)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2175783c8322b9f1a797522de362