### PR TITLE
refactor: remove next-contentlayer for Next.js 14

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,4 @@
 import type { NextConfig } from "next";
-import { withContentlayer } from "next-contentlayer";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -9,4 +8,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withContentlayer(nextConfig);
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build && npx pagefind --site out",
+    "dev": "contentlayer build && next dev",
+    "build": "contentlayer build && next build && npx pagefind --site out",
     "start": "next start",
     "lint": "next lint"
   },
@@ -23,7 +23,6 @@
     "eslint": "8.50.0",
     "eslint-config-next": "14.1.0",
     "contentlayer": "^0.3.4",
-    "next-contentlayer": "^0.3.4",
     "reading-time": "^1.5.0",
     "remark-gfm": "^3.0.1"
   }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { allPosts } from "contentlayer/generated";
 import { MDXComponents } from "@/components/mdx-components";
-import { useMDXComponent } from "next-contentlayer/hooks";
+import { useMDXComponent } from "@/lib/mdx";
 import type { Metadata } from "next";
 import { absoluteUrl } from "@/lib/site";
 import Comments from "@/components/Comments";

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { allProjects } from "contentlayer/generated";
 import { MDXComponents } from "@/components/mdx-components";
-import { useMDXComponent } from "next-contentlayer/hooks";
+import { useMDXComponent } from "@/lib/mdx";
 import type { Metadata } from "next";
 import { absoluteUrl } from "@/lib/site";
 

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+import * as runtime from "react/jsx-runtime";
+
+export function useMDXComponent(code: string) {
+  return React.useMemo(() => {
+    const fn = new Function("React", ...Object.keys(runtime), `${code}; return MDXContent;`);
+    return fn(React, ...Object.values(runtime));
+  }, [code]);
+}


### PR DESCRIPTION
## Summary
- drop `next-contentlayer` and run `contentlayer` separately
- add custom `useMDXComponent` hook for rendering compiled MDX

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: contentlayer: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c22b9fda88322ba0a0a717439e85a